### PR TITLE
Added absoluteTime as config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Add module configuration to config.js.
 |`destination`|The target location.<br><br>**Example:** `Frankfurt HBF`<br>This value is **REQUIRED**|
 |`maxConnections`|How many connections should be displayed?<br><br>**Default value:** `3`|
 |`updateInterval`|How often does the content needs to be fetched? (Minutes)<br><br>**Default value:** `5`|
+|`absoluteTime`|If `true` displays the departure time as 'at hh:mm', if `false` displays 'in xx mins'<br><br>**Default value:** `false`|
 |`animationSpeed`|Speed of the update animation. (Seconds)<br><br>**Default value:** `1`|
 
 ## Special Thanks

--- a/localtransport.js
+++ b/localtransport.js
@@ -16,6 +16,7 @@ Module.register('localtransport', {
     units: 'metric',
     alternatives: true,
     maxAlternatives: 3,
+	absoluteTime: false,
     apiBase: 'https://maps.googleapis.com/',
     apiEndpoint: 'maps/api/directions/json'
   },
@@ -41,16 +42,23 @@ Module.register('localtransport', {
       params += '&destination=' + this.config.destination;
       params += '&key=' + this.config.api_key;
       params += '&traffic_model=' + this.config.traffic_model;
-      params += '&departure_time=now';
-      params += '&alternatives=true';
+      params += '&departure_time=' + this.config.departure_time; 
+      params += '&alternatives=' + this.config.alternatives;
       return params;
   },
   renderLeg: function(wrapper, leg){
     var depature = leg.departure_time.value * 1000;
     var arrival = leg.arrival_time.value * 1000;
     var span = document.createElement("div");
-    span.innerHTML =
-      moment(depature).fromNow()
+	if (!this.config.absoluteTime) {
+		span.innerHTML = moment(depature).fromNow();
+	} else {
+		if (config.timeFormat !== 24) {
+			span.innerHTML = 'at ' + moment(depature).format('h:mm A');
+		} else {
+			span.innerHTML = 'at ' + moment(depature).format('HH:mm');
+		}
+	}
       // + this.translate('TRAVEL_TIME') + ": "
       // + moment.duration(moment(arrival).diff(depature, 'minutes'), 'minutes').humanize()
       ;


### PR DESCRIPTION
Adds a absoluteTime flag to display time as 'in xx mins', false, default or 'at hh:mm' when true.

Also fixed departure_time and alternatives in getParams to use config variables 